### PR TITLE
Fix ffmpeg dependency and don't import project in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ More information on the format is available on the
 The primay aim of this project was to be able to extract GPS tracks
 from GoPro video files, so the GPS part is more tested.
 
-We use `python-ffmpeg` to extract the GPMF stream from video files.
+We use `ffmpeg-python` to extract the GPMF stream from video files.
 
 ```python
 import gpmf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 matplotlib
 gpxpy
-python-ffmpeg
+ffmpeg-python
 geopandas
 descartes
 contextily

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 import pathlib
-from gpmf import __version__
+__version__ = "0.1"
 
 HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         install_requires=[
             "numpy", "pandas", "gpxpy",
-            "python-ffmpeg", "geopandas",
+            "ffmpeg-python", "geopandas",
             "contextily", "descartes"
         ],
         url="https://github.com/alexis-mignon/pygpmf"


### PR DESCRIPTION
Fixes #1.

Also it's a bad practice to import the project in setup.py, as at the time of setup the environment likely doesn't have the required dependencies like numpy. There are a couple ways to resolve this while keeping the 2 versions in the same place, see https://packaging.python.org/en/latest/guides/single-sourcing-package-version/. 