### PR TITLE
GPS5 in gps_block seems to be faulty for some videos, added checks to counter that

### DIFF
--- a/gpmf/gps.py
+++ b/gpmf/gps.py
@@ -146,8 +146,6 @@ def make_pgx_segment(gps_blocks, first_only=False, speeds_as_extensions=True):
             time = datetime.strptime(gps_data.timestamp, "%Y-%m-%d %H:%M:%S.%f")
             # Reference says the frequency is about 18 Hz and other GPS data about 1Hz
 
-            print(gps_data)
-
             if((type(gps_data.latitude) != type(np.array([]))) and (type(gps_data.longitude) != type(np.array([])))):
                 tp = gpxpy.gpx.GPXTrackPoint(
                     latitude=gps_data.latitude,

--- a/gpmf/gps.py
+++ b/gpmf/gps.py
@@ -146,6 +146,8 @@ def make_pgx_segment(gps_blocks, first_only=False, speeds_as_extensions=True):
             time = datetime.strptime(gps_data.timestamp, "%Y-%m-%d %H:%M:%S.%f")
             # Reference says the frequency is about 18 Hz and other GPS data about 1Hz
 
+            print(gps_data)
+
             if((type(gps_data.latitude) != []) and (type(gps_data.longitude) != [])):
                 tp = gpxpy.gpx.GPXTrackPoint(
                     latitude=gps_data.latitude,

--- a/gpmf/gps.py
+++ b/gpmf/gps.py
@@ -146,9 +146,7 @@ def make_pgx_segment(gps_blocks, first_only=False, speeds_as_extensions=True):
             time = datetime.strptime(gps_data.timestamp, "%Y-%m-%d %H:%M:%S.%f")
             # Reference says the frequency is about 18 Hz and other GPS data about 1Hz
 
-            print(gps_data)
-
-            if((type(gps_data.latitude) != []) and (type(gps_data.longitude) != [])):
+            if((type(gps_data.latitude) != type([])) and (type(gps_data.longitude) != type([]))):
                 tp = gpxpy.gpx.GPXTrackPoint(
                     latitude=gps_data.latitude,
                     longitude=gps_data.longitude,

--- a/gpmf/gps.py
+++ b/gpmf/gps.py
@@ -148,7 +148,7 @@ def make_pgx_segment(gps_blocks, first_only=False, speeds_as_extensions=True):
 
             print(gps_data)
 
-            if((type(gps_data.latitude) != type([])) and (type(gps_data.longitude) != type([]))):
+            if((type(gps_data.latitude) != type(np.array([]))) and (type(gps_data.longitude) != type(np.array([])))):
                 tp = gpxpy.gpx.GPXTrackPoint(
                     latitude=gps_data.latitude,
                     longitude=gps_data.longitude,

--- a/gpmf/gps.py
+++ b/gpmf/gps.py
@@ -146,6 +146,8 @@ def make_pgx_segment(gps_blocks, first_only=False, speeds_as_extensions=True):
             time = datetime.strptime(gps_data.timestamp, "%Y-%m-%d %H:%M:%S.%f")
             # Reference says the frequency is about 18 Hz and other GPS data about 1Hz
 
+            print(gps_data)
+
             if((type(gps_data.latitude) != type([])) and (type(gps_data.longitude) != type([]))):
                 tp = gpxpy.gpx.GPXTrackPoint(
                     latitude=gps_data.latitude,


### PR DESCRIPTION
These checks ensure that if there is any faulty gps_block, it does not process it.

Countered this error:
operands could not be broadcast together with shapes (0,) (5,) 
on this line: gps_data = list(map(gpmf.gps.parse_gps_block, gps_blocks))